### PR TITLE
[FIX] wrong word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chest Python Package
+# MythChest Python Package
 
 The chest box for collecting useful python function or objects that can be common used for different projects
 


### PR DESCRIPTION
#2 
- Fix README.md: `Chest` -> `MythChest`